### PR TITLE
Allow service instances to use credential store

### DIFF
--- a/components/filesystem-credential-admin/src/lib.rs
+++ b/components/filesystem-credential-admin/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_main]
 
-use exports::componentized::services::credential_admin::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_admin::{Credential, Error, Guest, ServiceId};
 use serde_json;
 use std::collections::HashMap;
 use std::fs;
@@ -14,35 +12,32 @@ const PATH_DEFAULT: &str = "services";
 pub(crate) struct FilesystemCredentialAdmin;
 
 impl FilesystemCredentialAdmin {
-    fn get_binding_path(binding_id: ServiceBindingId) -> Result<PathBuf, Error> {
+    fn get_path(id: ServiceId) -> Result<PathBuf, Error> {
         let base_path = wasi::config::store::get(PATH_KEY)
             .map_err(|e| Error::from(e.to_string()))?
             .unwrap_or(String::from(PATH_DEFAULT));
 
-        Ok(PathBuf::new()
-            .join(base_path)
-            .join("credentials")
-            .join(binding_id))
+        Ok(PathBuf::new().join(base_path).join("credentials").join(id))
     }
 }
 
 impl Guest for FilesystemCredentialAdmin {
-    fn publish(binding_id: ServiceBindingId, credentials: Vec<Credential>) -> Result<(), Error> {
+    fn publish(id: ServiceId, credentials: Vec<Credential>) -> Result<(), Error> {
         let mut creds = HashMap::new();
         for Credential { key, value } in credentials {
             creds.insert(key, value);
         }
         let creds = serde_json::to_string(&creds).map_err(|e| Error::from(e.to_string()))?;
 
-        let path = FilesystemCredentialAdmin::get_binding_path(binding_id)?;
+        let path = FilesystemCredentialAdmin::get_path(id)?;
         let mut dir = path.clone();
         dir.pop();
         fs::create_dir_all(dir).map_err(|e| Error::from(e.to_string()))?;
         fs::write(path, creds).map_err(|e| Error::from(e.to_string()))
     }
 
-    fn destroy(id: ServiceBindingId) -> Result<(), Error> {
-        fs::remove_file(FilesystemCredentialAdmin::get_binding_path(id)?)
+    fn destroy(id: ServiceId) -> Result<(), Error> {
+        fs::remove_file(FilesystemCredentialAdmin::get_path(id)?)
             .map_err(|e| Error::from(e.to_string()))
     }
 }

--- a/components/filesystem-credential-store/src/lib.rs
+++ b/components/filesystem-credential-store/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_main]
 
-use exports::componentized::services::credential_store::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_store::{Credential, Error, Guest, ServiceId};
 use serde_json;
 use std::collections::HashMap;
 use std::fs;
@@ -14,20 +12,17 @@ const PATH_DEFAULT: &str = "services";
 pub(crate) struct FilesystemCredentialStore;
 
 impl FilesystemCredentialStore {
-    fn get_credential_path(binding_id: ServiceBindingId) -> Result<PathBuf, Error> {
+    fn get_credential_path(id: ServiceId) -> Result<PathBuf, Error> {
         let base_path = wasi::config::store::get(PATH_KEY)
             .map_err(|e| Error::from(e.to_string()))?
             .unwrap_or(String::from(PATH_DEFAULT));
 
-        Ok(PathBuf::new()
-            .join(base_path)
-            .join("credentials")
-            .join(binding_id))
+        Ok(PathBuf::new().join(base_path).join("credentials").join(id))
     }
 }
 
 impl Guest for FilesystemCredentialStore {
-    fn fetch(id: ServiceBindingId) -> Result<Vec<Credential>, Error> {
+    fn fetch(id: ServiceId) -> Result<Vec<Credential>, Error> {
         let bytes = fs::read(FilesystemCredentialStore::get_credential_path(id)?)
             .map_err(|e| Error::from(e.to_string()))?;
         let creds: HashMap<String, String> =

--- a/components/keyvalue-credential-admin/src/lib.rs
+++ b/components/keyvalue-credential-admin/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_main]
 
-use exports::componentized::services::credential_admin::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_admin::{Credential, Error, Guest, ServiceId};
 use serde_json;
 use std::collections::HashMap;
 use wasi::keyvalue::store::{open, Bucket};
@@ -43,7 +41,7 @@ impl KeyvalueCredentialAdmin {
 }
 
 impl Guest for KeyvalueCredentialAdmin {
-    fn publish(binding_id: ServiceBindingId, credentials: Vec<Credential>) -> Result<(), Error> {
+    fn publish(id: ServiceId, credentials: Vec<Credential>) -> Result<(), Error> {
         let mut creds = HashMap::new();
         for Credential { key, value } in credentials {
             creds.insert(key, value);
@@ -51,13 +49,13 @@ impl Guest for KeyvalueCredentialAdmin {
         let creds = serde_json::to_vec(&creds).map_err(Self::map_serde_err)?;
 
         Self::get_bucket()?
-            .set(&binding_id, &creds)
+            .set(&id, &creds)
             .map_err(Self::map_keyvalue_err)
     }
 
-    fn destroy(binding_id: ServiceBindingId) -> Result<(), Error> {
+    fn destroy(id: ServiceId) -> Result<(), Error> {
         Self::get_bucket()?
-            .delete(&binding_id)
+            .delete(&id)
             .map_err(Self::map_keyvalue_err)
     }
 }

--- a/components/keyvalue-credential-store/src/lib.rs
+++ b/components/keyvalue-credential-store/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_main]
 
-use exports::componentized::services::credential_store::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_store::{Credential, Error, Guest, ServiceId};
 use serde_json;
 use std::collections::HashMap;
 use std::vec;
@@ -44,9 +42,9 @@ impl KeyvalueCredentialStore {
 }
 
 impl Guest for KeyvalueCredentialStore {
-    fn fetch(binding_id: ServiceBindingId) -> Result<Vec<Credential>, Error> {
+    fn fetch(id: ServiceId) -> Result<Vec<Credential>, Error> {
         let creds = Self::get_bucket()?
-            .get(&binding_id)
+            .get(&id)
             .map_err(Self::map_keyvalue_err)?
             .unwrap_or(vec![]);
 

--- a/components/webhook-credential-admin/src/lib.rs
+++ b/components/webhook-credential-admin/src/lib.rs
@@ -2,9 +2,7 @@
 
 use std::collections::HashMap;
 
-use exports::componentized::services::credential_admin::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_admin::{Credential, Error, Guest, ServiceId};
 use wasi::config::store as config;
 use wasi::http::{
     outgoing_handler::handle,
@@ -74,7 +72,7 @@ impl WebhookCredentialAdmin {
 }
 
 impl Guest for WebhookCredentialAdmin {
-    fn publish(binding_id: ServiceBindingId, credentials: Vec<Credential>) -> Result<(), Error> {
+    fn publish(id: ServiceId, credentials: Vec<Credential>) -> Result<(), Error> {
         let mut creds = HashMap::new();
         for cred in credentials {
             creds.insert(cred.key, cred.value);
@@ -84,7 +82,7 @@ impl Guest for WebhookCredentialAdmin {
         let response = Self::make_request(
             "/services/credentials/publish",
             vec![
-                ("service-binding-id", &binding_id),
+                ("service-id", &id),
                 ("service-credentials", &service_credentials),
             ],
         )?;
@@ -94,11 +92,9 @@ impl Guest for WebhookCredentialAdmin {
         }
     }
 
-    fn destroy(binding_id: ServiceBindingId) -> Result<(), Error> {
-        let response = Self::make_request(
-            "/services/credentials/destroy",
-            vec![("service-binding-id", &binding_id)],
-        )?;
+    fn destroy(id: ServiceId) -> Result<(), Error> {
+        let response =
+            Self::make_request("/services/credentials/destroy", vec![("service-id", &id)])?;
         match response.status() {
             204 => Ok(()),
             code => Err(Error::from(format!("unexpected http status {code}"))),

--- a/components/webhook-credential-store/src/lib.rs
+++ b/components/webhook-credential-store/src/lib.rs
@@ -2,9 +2,7 @@
 
 use std::collections::HashMap;
 
-use exports::componentized::services::credential_store::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_store::{Credential, Error, Guest, ServiceId};
 use wasi::config::store as config;
 use wasi::http::{
     outgoing_handler::handle,
@@ -76,11 +74,9 @@ impl WebhookCredentialStore {
 }
 
 impl Guest for WebhookCredentialStore {
-    fn fetch(binding_id: ServiceBindingId) -> Result<Vec<Credential>, Error> {
-        let response = Self::make_request(
-            "/services/credentials/fetch",
-            vec![("service-binding-id", &binding_id)],
-        )?;
+    fn fetch(id: ServiceId) -> Result<Vec<Credential>, Error> {
+        let response =
+            Self::make_request("/services/credentials/fetch", vec![("service-id", &id)])?;
         match response.status() {
             200 => {
                 let body = response.consume().unwrap();

--- a/components/wit/deps/componentized-services/package.wit
+++ b/components/wit/deps/componentized-services/package.wit
@@ -1,9 +1,11 @@
 package componentized:services;
 
 interface types {
-  type service-instance-id = string;
+  type service-id = string;
 
-  type service-binding-id = string;
+  type service-instance-id = service-id;
+
+  type service-binding-id = service-id;
 
   record credential {
     key: string,
@@ -22,34 +24,34 @@ interface types {
   type error = string;
 }
 
-/// Credential Stores allow a client to fetch credentials for a specific binding. The platform
-/// typically implements this interface keeping the implementation details of credential storage
-/// hidden from the service lifecycle and users.
+/// Credential Stores allow a client to fetch credentials for a specific instance or binding. The
+/// platform typically implements this interface keeping the implementation details of credential
+/// storage hidden from the service lifecycle and users.
 interface credential-store {
-  use types.{service-binding-id, credential, error};
+  use types.{service-id, credential, error};
 
-  /// Fetch credentials from the store for a specific binding.
-  fetch: func(binding-id: service-binding-id) -> result<list<credential>, error>;
+  /// Fetch credentials from the store for a specific instance or binding.
+  fetch: func(id: service-id) -> result<list<credential>, error>;
 }
 
-/// Credential Admins manage the credentials for a binding. The platform typically implements this
-/// interface keeping the implementation details of credential storage hidden from the service
-/// lifecycle and users.
+/// Credential Admins manage the credentials for an instance or binding. The platform typically
+/// implements this interface keeping the implementation details of credential storage hidden from
+/// the service lifecycle and users.
 ///
 /// Some clients are not able to support rotating credentials. For those clients, creating a new
 /// binding is recommended. Once the previous credentials are no longer in use, the old binding can
 /// be unbound.
 interface credential-admin {
-  use types.{service-binding-id, credential, error};
+  use types.{service-id, credential, error};
 
-  /// Publish new or refreshed credentials to the store for use by the service binding. When
-  /// rotating credentials, the previously valid credentials should be revoked after calling
+  /// Publish new or refreshed credentials to the store for use by the service instance/binding.
+  /// When rotating credentials, the previously valid credentials should be revoked after calling
   /// publish with the new credentials.
-  publish: func(binding-id: service-binding-id, credentials: list<credential>) -> result<_, error>;
+  publish: func(id: service-id, credentials: list<credential>) -> result<_, error>;
 
-  /// Destroy credentials previously published for a binding. Valid credentials should be revoked
-  /// before calling destroy.
-  destroy: func(binding-id: service-binding-id) -> result<_, error>;
+  /// Destroy credentials previously published for a service instance or binding. Valid
+  /// credentials should be revoked before calling destroy.
+  destroy: func(id: service-id) -> result<_, error>;
 }
 
 /// Service lifecycle manage a specific type of service on demand. Allowed tiers and requested

--- a/tests/lifecycle-router/src/lib.rs
+++ b/tests/lifecycle-router/src/lib.rs
@@ -55,7 +55,6 @@ impl Guest for Lifecycle {
                 keyvalue_lifecycle::provision(&instance_id, &type_, tier, requests)
             }
         }?;
-        // mild abuse of the credential store by stashing the type for an instance rather than a binding
         componentized::services::credential_admin::publish(
             &instance_id,
             vec![Credential {
@@ -83,7 +82,6 @@ impl Guest for Lifecycle {
 
     fn destroy(instance_id: ServiceInstanceId, retain: Option<bool>) -> Result<(), Error> {
         let type_ = Lifecycle::get_type_for_instance_id(instance_id.clone())?;
-        // mild abuse of the credential store by stashing the type for an instance rather than a binding
         componentized::services::credential_admin::destroy(&instance_id)?;
         match Lifecycle::get_lifecycle(type_.clone())? {
             LifeycleType::Filesystem => filesystem_lifecycle::destroy(&instance_id, retain),

--- a/tests/service-cli/src/main.rs
+++ b/tests/service-cli/src/main.rs
@@ -141,7 +141,7 @@ enum CredentialCommands {
         id: ServiceId,
     },
 
-    /// Export credentials for a service instance binding as a wasi:config/store component
+    /// Export credentials for a service instance or binding as a wasi:config/store component
     #[command(arg_required_else_help = true)]
     Export {
         /// Identifier for the service instance or binding

--- a/tests/service-cli/src/main.rs
+++ b/tests/service-cli/src/main.rs
@@ -3,7 +3,7 @@ use componentized::services::credential_admin::{destroy, publish};
 use componentized::services::credential_store::fetch;
 use componentized::services::lifecycle;
 use componentized::services::types::{
-    Credential, Error, Request, Scope, ServiceBindingId, ServiceInstanceId, Tier,
+    Credential, Error, Request, Scope, ServiceBindingId, ServiceId, ServiceInstanceId, Tier,
 };
 use componentized::services_test_components::ops;
 use regex_lite::Regex;
@@ -113,40 +113,40 @@ struct CredentialsArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 enum CredentialCommands {
-    /// Publish credentials for a binding
+    /// Publish credentials for a service instance or binding
     #[command(arg_required_else_help = true)]
     Publish {
-        /// Identifier for the service binding
+        /// Identifier for the service instance or binding
         #[arg(required = true)]
-        binding_id: ServiceBindingId,
+        id: ServiceId,
 
         /// Credentials to publish key=value
         #[arg(short, long)]
         credentials: Vec<Credential>,
     },
 
-    /// Destroy credentials for a binding
+    /// Destroy credentials for a service instance or binding
     #[command(arg_required_else_help = true)]
     Destroy {
-        /// Identifier for the service binding
+        /// Identifier for the service instance or binding
         #[arg(required = true)]
-        binding_id: ServiceBindingId,
+        id: ServiceId,
     },
 
-    /// Fetch credentials for a binding
+    /// Fetch credentials for a service instance or binding
     #[command(arg_required_else_help = true)]
     Fetch {
-        /// Identifier for the service binding
+        /// Identifier for the service instance or binding
         #[arg(required = true)]
-        binding_id: ServiceBindingId,
+        id: ServiceId,
     },
 
-    /// Export credentials for a binding as a wasi:config/store component
+    /// Export credentials for a service instance binding as a wasi:config/store component
     #[command(arg_required_else_help = true)]
     Export {
-        /// Identifier for the service binding
+        /// Identifier for the service instance or binding
         #[arg(required = true)]
-        binding_id: ServiceBindingId,
+        id: ServiceId,
     },
 }
 
@@ -371,51 +371,48 @@ fn main() -> Result<(), ()> {
             Ok(())
         }
         Commands::Credentials(store) => match store.command {
-            CredentialCommands::Publish {
-                binding_id,
-                credentials,
-            } => {
-                eprintln!("Publish creds for {}", binding_id);
+            CredentialCommands::Publish { id, credentials } => {
+                eprintln!("Publish creds for {}", id);
 
-                publish(&binding_id, &credentials).map_err(|e: Error| {
-                    eprintln!("Error publishing {}: {}", binding_id, e);
+                publish(&id, &credentials).map_err(|e: Error| {
+                    eprintln!("Error publishing {}: {}", id, e);
                 })
             }
-            CredentialCommands::Destroy { binding_id } => {
-                eprintln!("Destroy creds for {}", binding_id);
+            CredentialCommands::Destroy { id } => {
+                eprintln!("Destroy creds for {}", id);
 
-                destroy(&binding_id).map_err(|e: Error| {
-                    eprintln!("Error destroying {}: {}", binding_id, e);
+                destroy(&id).map_err(|e: Error| {
+                    eprintln!("Error destroying {}: {}", id, e);
                 })
             }
-            CredentialCommands::Fetch { binding_id } => {
-                eprintln!("Fetch creds for {}", binding_id);
+            CredentialCommands::Fetch { id } => {
+                eprintln!("Fetch creds for {}", id);
 
-                let creds = fetch(&binding_id).map_err(|e: Error| {
-                    eprintln!("Error fetching {}: {}", binding_id, e);
+                let creds = fetch(&id).map_err(|e: Error| {
+                    eprintln!("Error fetching {}: {}", id, e);
                 })?;
                 println!("{:#?}", creds);
 
                 Ok(())
             }
-            CredentialCommands::Export { binding_id } => {
-                eprintln!("Export creds for {}", binding_id);
+            CredentialCommands::Export { id } => {
+                eprintln!("Export creds for {}", id);
 
-                let creds: Vec<(String, String)> = fetch(&binding_id)
+                let creds: Vec<(String, String)> = fetch(&id)
                     .map_err(|e: Error| {
-                        eprintln!("Error fetching {}: {}", binding_id, e);
+                        eprintln!("Error fetching {}: {}", id, e);
                     })?
                     .iter()
                     .map(|cred| (cred.key.clone(), cred.value.clone()))
                     .collect();
                 let config =
                     componentized::config::factory::build_component(&creds).map_err(|e| {
-                        eprintln!("Error creating config {}: {}", binding_id, e);
+                        eprintln!("Error creating config {}: {}", id, e);
                     })?;
 
                 let mut output = Box::new(io::stdout()) as Box<dyn Write>;
                 output.write_all(&config).map_err(|e| {
-                    eprintln!("Error writing config {}: {}", binding_id, e);
+                    eprintln!("Error writing config {}: {}", id, e);
                 })?;
 
                 Ok(())

--- a/tests/stub-credential-admin/src/lib.rs
+++ b/tests/stub-credential-admin/src/lib.rs
@@ -1,28 +1,22 @@
 #![no_main]
 
-use exports::componentized::services::credential_admin::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_admin::{Credential, Error, Guest, ServiceId};
 use wasi::logging::logging::{log, Level};
 
 pub(crate) struct StubCredentialAdmin;
 
 impl Guest for StubCredentialAdmin {
-    fn publish(binding_id: ServiceBindingId, credentials: Vec<Credential>) -> Result<(), Error> {
+    fn publish(id: ServiceId, credentials: Vec<Credential>) -> Result<(), Error> {
         log(
             Level::Info,
             "credential-admin",
-            &format!("publish binding-id={binding_id} credentials={credentials:?}"),
+            &format!("publish id={id} credentials={credentials:?}"),
         );
         Ok(())
     }
 
-    fn destroy(binding_id: ServiceBindingId) -> Result<(), Error> {
-        log(
-            Level::Info,
-            "credential-admin",
-            &format!("destroy binding-id={binding_id}"),
-        );
+    fn destroy(id: ServiceId) -> Result<(), Error> {
+        log(Level::Info, "credential-admin", &format!("destroy id={id}"));
         Ok(())
     }
 }

--- a/tests/stub-credential-store/src/lib.rs
+++ b/tests/stub-credential-store/src/lib.rs
@@ -1,19 +1,13 @@
 #![no_main]
 
-use exports::componentized::services::credential_store::{
-    Credential, Error, Guest, ServiceBindingId,
-};
+use exports::componentized::services::credential_store::{Credential, Error, Guest, ServiceId};
 use wasi::logging::logging::{log, Level};
 
 pub(crate) struct StubCredentialStore;
 
 impl Guest for StubCredentialStore {
-    fn fetch(binding_id: ServiceBindingId) -> Result<Vec<Credential>, Error> {
-        log(
-            Level::Info,
-            "credential-store",
-            &format!("fetch binding-id={binding_id}"),
-        );
+    fn fetch(id: ServiceId) -> Result<Vec<Credential>, Error> {
+        log(Level::Info, "credential-store", &format!("fetch id={id}"));
         Ok(vec![])
     }
 }

--- a/tests/wit/deps/componentized-services/package.wit
+++ b/tests/wit/deps/componentized-services/package.wit
@@ -1,9 +1,11 @@
 package componentized:services;
 
 interface types {
-  type service-instance-id = string;
+  type service-id = string;
 
-  type service-binding-id = string;
+  type service-instance-id = service-id;
+
+  type service-binding-id = service-id;
 
   record credential {
     key: string,
@@ -22,34 +24,34 @@ interface types {
   type error = string;
 }
 
-/// Credential Stores allow a client to fetch credentials for a specific binding. The platform
-/// typically implements this interface keeping the implementation details of credential storage
-/// hidden from the service lifecycle and users.
+/// Credential Stores allow a client to fetch credentials for a specific instance or binding. The
+/// platform typically implements this interface keeping the implementation details of credential
+/// storage hidden from the service lifecycle and users.
 interface credential-store {
-  use types.{service-binding-id, credential, error};
+  use types.{service-id, credential, error};
 
-  /// Fetch credentials from the store for a specific binding.
-  fetch: func(binding-id: service-binding-id) -> result<list<credential>, error>;
+  /// Fetch credentials from the store for a specific instance or binding.
+  fetch: func(id: service-id) -> result<list<credential>, error>;
 }
 
-/// Credential Admins manage the credentials for a binding. The platform typically implements this
-/// interface keeping the implementation details of credential storage hidden from the service
-/// lifecycle and users.
+/// Credential Admins manage the credentials for an instance or binding. The platform typically
+/// implements this interface keeping the implementation details of credential storage hidden from
+/// the service lifecycle and users.
 ///
 /// Some clients are not able to support rotating credentials. For those clients, creating a new
 /// binding is recommended. Once the previous credentials are no longer in use, the old binding can
 /// be unbound.
 interface credential-admin {
-  use types.{service-binding-id, credential, error};
+  use types.{service-id, credential, error};
 
-  /// Publish new or refreshed credentials to the store for use by the service binding. When
-  /// rotating credentials, the previously valid credentials should be revoked after calling
+  /// Publish new or refreshed credentials to the store for use by the service instance/binding.
+  /// When rotating credentials, the previously valid credentials should be revoked after calling
   /// publish with the new credentials.
-  publish: func(binding-id: service-binding-id, credentials: list<credential>) -> result<_, error>;
+  publish: func(id: service-id, credentials: list<credential>) -> result<_, error>;
 
-  /// Destroy credentials previously published for a binding. Valid credentials should be revoked
-  /// before calling destroy.
-  destroy: func(binding-id: service-binding-id) -> result<_, error>;
+  /// Destroy credentials previously published for a service instance or binding. Valid
+  /// credentials should be revoked before calling destroy.
+  destroy: func(id: service-id) -> result<_, error>;
 }
 
 /// Service lifecycle manage a specific type of service on demand. Allowed tiers and requested

--- a/wit/credentials.wit
+++ b/wit/credentials.wit
@@ -1,30 +1,30 @@
-/// Credential Stores allow a client to fetch credentials for a specific binding. The platform
-/// typically implements this interface keeping the implementation details of credential storage
-/// hidden from the service lifecycle and users.
+/// Credential Stores allow a client to fetch credentials for a specific instance or binding. The
+/// platform typically implements this interface keeping the implementation details of credential
+/// storage hidden from the service lifecycle and users.
 interface credential-store {
-    use types.{service-binding-id, credential, error};
+    use types.{service-id, credential, error};
 
-    /// Fetch credentials from the store for a specific binding.
-    fetch: func(binding-id: service-binding-id) -> result<list<credential>, error>;
+    /// Fetch credentials from the store for a specific instance or binding.
+    fetch: func(id: service-id) -> result<list<credential>, error>;
 }
 
-/// Credential Admins manage the credentials for a binding. The platform typically implements this
-/// interface keeping the implementation details of credential storage hidden from the service
-/// lifecycle and users.
+/// Credential Admins manage the credentials for an instance or binding. The platform typically
+/// implements this interface keeping the implementation details of credential storage hidden from
+/// the service lifecycle and users.
 /// 
 /// Some clients are not able to support rotating credentials. For those clients, creating a new
 /// binding is recommended. Once the previous credentials are no longer in use, the old binding can
 /// be unbound.
 interface credential-admin {
-    use types.{service-binding-id, credential, error};
+    use types.{service-id, credential, error};
 
-    /// Publish new or refreshed credentials to the store for use by the service binding. When
-    /// rotating credentials, the previously valid credentials should be revoked after calling
+    /// Publish new or refreshed credentials to the store for use by the service instance/binding.
+    /// When rotating credentials, the previously valid credentials should be revoked after calling
     /// publish with the new credentials.
-    publish: func(binding-id: service-binding-id, credentials: list<credential>) -> result<_, error>;
+    publish: func(id: service-id, credentials: list<credential>) -> result<_, error>;
 
-    /// Destroy credentials previously published for a binding. Valid credentials should be revoked
-    /// before calling destroy.
-    destroy: func(binding-id: service-binding-id) -> result<_, error>;
+    /// Destroy credentials previously published for a service instance or binding. Valid
+    /// credentials should be revoked before calling destroy.
+    destroy: func(id: service-id) -> result<_, error>;
 }
 

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,7 +1,8 @@
 
 interface types {
-    type service-instance-id = string;
-    type service-binding-id = string;
+    type service-id = string;
+    type service-instance-id = service-id;
+    type service-binding-id = service-id;
 
     record credential {
         key: string,


### PR DESCRIPTION
The credential-store and credential-admin interfaces were originally intended to store credentials for service bindings. Some lifecycles also need to interact with credentials for service instances. Now service instance and bindings IDs can be used with the credential store.

This pattern was previously used within the test components. Now it is formally allowed.